### PR TITLE
Add lib.mkDefault tag to the systemd timer value

### DIFF
--- a/utils/bento.nix
+++ b/utils/bento.nix
@@ -7,7 +7,7 @@
 in {
   systemd.services.bento-upgrade = {
     enable = true;
-    startAt = "${timer}";
+    startAt = lib.mkDefault "${timer}";
     path = with pkgs; [openssh git nixos-rebuild nix gzip];
     serviceConfig.Type = "oneshot";
     script = ''


### PR DESCRIPTION
I would like to use bento's SELF_UPDATE feature to replace nix's AutoUpdate one.  An update every 15 minutes is to much for my use case. So I added lib.mkDefault in front of the timer value to be able to set per host values in their own config file with systemd.services.bento-upgrade.startAt = "XXX"; 
And I thought that maybe someone will be interested as well.
