### PR TITLE
add a config option to not build the config locally

### DIFF
--- a/bento
+++ b/bento
@@ -2,6 +2,7 @@
 
 TIMEOUT=20
 REMOTE_PORT=22
+NOLOCALBUILD=0
 
 # FUNCTION LIBRARIES
 usage() {                                                                                    
@@ -529,7 +530,11 @@ deploy_files() {
 
         if [ "$CHANGES" -ne 0 ]
         then
-            build_config "${STAGING_DIR}/${dest}/config/" "build" "" "${dest}"
+            if [ $NOLOCALBUILD -eq 1 ]; then
+              build_config "${STAGING_DIR}/${dest}/config/" "dry-build" "" "${dest}"
+            else
+              build_config "${STAGING_DIR}/${dest}/config/" "build" "" "${dest}"
+            fi
             echo " update required"
             # copy files in the chroot
             install -d -o root -g sftp_users -m 755 "${CHROOT_DIR}"

--- a/config.sh.sample
+++ b/config.sh.sample
@@ -9,3 +9,5 @@ REMOTE_IP=myserver.example
 # port to connect to the remote server
 # default is 22
 #REMOTE_PORT=22
+# don't build locally
+#NOLOCALBUILD=1


### PR DESCRIPTION
fixes #5 

I have a deployment server which also runs a nix binary cache (attic). The deployment server is rather slow and I have a (local) CI machine which regularly pushes updates to the binary cache. For me it doesn't make sense to build the config (again) by bento, even if it just fetches all the build artifacts from attic. 

So I added an option to not build the config by bento. I suppose it could be beneficial for the following usecases:
- slow or underpowered deployment server 
- wrong architecture of the deployment server (e.g. Raspberry Pi)
- limited disk space of the deployment server
- convoluted build environments with CI server (or any server which builds the config separately) 

What do you think?