### PR TITLE
replace "path:" with "./"

### DIFF
--- a/bento
+++ b/bento
@@ -629,7 +629,7 @@ FLAKES=$(
 for flakes in $(find . -name flake.nix)
 do
     TARGET="$(dirname "${flakes}")"
-    nix flake show --json "path:$TARGET" | jq -r '.nixosConfigurations | keys[]'
+    nix flake show --json "./$TARGET" | jq -r '.nixosConfigurations | keys[]'
 done
 )
 
@@ -649,7 +649,7 @@ else
         for flakes in $(find . -name flake.nix)
         do
             TARGET="$(dirname $flakes)"
-            FLAKES_IN_DIR=$(nix flake show --json "path:$TARGET" | jq -r '.nixosConfigurations | keys[]')
+            FLAKES_IN_DIR=$(nix flake show --json "./$TARGET" | jq -r '.nixosConfigurations | keys[]')
             if echo "${FLAKES_IN_DIR}" | grep "^${NAME}$" >/dev/null
             then
                 # we need to keep the flake directory path
@@ -705,7 +705,7 @@ then
         test -d "$i" || continue
         if [ -f "$i/flake.nix" ]
         then
-            for host in $(nix flake show --json "path:${i}" | jq -r '.nixosConfigurations | keys[]')
+            for host in $(nix flake show --json "./${i}" | jq -r '.nixosConfigurations | keys[]')
             do
                 test -n "${SINGLE_FLAKE}" && ! [ "$host" = "${SINGLE_FLAKE}" ] && continue
                 printf "%${PRETTY_OUT_COLUMN}s " "${host}"
@@ -749,7 +749,7 @@ then
     do
         if [ -f "$i/flake.nix" ]
         then
-            for host in $(nix flake show --json "path:${i}" | jq -r '.nixosConfigurations | keys[]')
+            for host in $(nix flake show --json "./${i}" | jq -r '.nixosConfigurations | keys[]')
             do
                 test -n "${SINGLE_FLAKE}" && ! [ "$host" = "${SINGLE_FLAKE}" ] && continue
                 deploy_files "$i" "${host}" "${host}"
@@ -785,7 +785,7 @@ then
             echo "$directory"
             if [ -z "$2" ]
             then
-                nix flake update path:"$directory"
+                nix flake update ./"$directory"
             else
                 cd "$directory" >/dev/null || exit 5
                 nix flake lock --update-input "$2"


### PR DESCRIPTION
On newer nix versions (> 2.18) the "path:" settings will lead to evaluation errors when the flake uses symbolic links.

a typical error message would be:

`error: access to absolute path '/lib' is forbidden in pure evaluation mode (use '--impure' to override)`

when `/lib` actually is `./lib`.

When "path:" is replaced by just using the flake's path no evaluation error is shown. As per the man page of `nix flake` the "path" attribute reffers to the local path of the flake.

This can just be removed (AFAIK) by referencing to the path as a positional argument.

Possible related issues:
https://github.com/NixOS/nix/issues/11030
original PR introducing the error message https://github.com/NixOS/nix/pull/9497